### PR TITLE
fix(kontainer): runtime 6.9→6.10, appstream lint exceptions, x-version

### DIFF
--- a/flatpaks/io.github.DenysMb.Kontainer/exceptions.json
+++ b/flatpaks/io.github.DenysMb.Kontainer/exceptions.json
@@ -3,6 +3,8 @@
         "appid-filename-mismatch",
         "finish-args-desktopfile-filesystem-access",
         "finish-args-flatpak-spawn-access",
-        "appstream-missing-vcs-browser-url"
+        "appstream-missing-vcs-browser-url",
+        "appstream-external-screenshot-url",
+        "appstream-screenshots-not-mirrored-in-ostree"
     ]
 }

--- a/flatpaks/io.github.DenysMb.Kontainer/manifest.yaml
+++ b/flatpaks/io.github.DenysMb.Kontainer/manifest.yaml
@@ -1,6 +1,6 @@
 # Auto-imported from flatpak-tracker issue #528 — do not edit manually
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: kontainer
 finish-args:
@@ -23,6 +23,6 @@ modules:
     tag: 1.4.1
     commit: bac90f1aa49a1fb465e445da156686964f4a7882
 app-id: io.github.DenysMb.Kontainer
-x-version: ''
+x-version: '1.4.1'
 x-arches:
 - x86_64

--- a/skills/app-gotchas.md
+++ b/skills/app-gotchas.md
@@ -7,6 +7,7 @@ Per-app known issues and workarounds. Each app has a dedicated `GOTCHAS.md` in i
 |---|---|---|
 | ghostty | `flatpaks/ghostty/GOTCHAS.md` | sandbox escape (`--talk-name=org.freedesktop.Flatpak`), aggressive `*.so`/`*.a` cleanup globs |
 | goose | `flatpaks/goose/GOTCHAS.md` | bundle-repack (no metainfo inject), x86_64 only, missing `<categories>` (Flathub-only violation) |
+| io.github.DenysMb.Kontainer | (inline in `app-gotchas.md`) | `appstream-external-screenshot-url` + `appstream-screenshots-not-mirrored-in-ostree` — screenshots not mirrored to Flathub CDN; permanent exception (both stages) |
 | lmstudio | `flatpaks/lmstudio/GOTCHAS.md` | icon omitted (resize unsolved), `--filesystem=home` intentional, x86_64 only, manual Renovate required |
 | firefox-nightly | `flatpaks/firefox-nightly/GOTCHAS.md` | app-id is `org.mozilla.firefox.nightly` (renamed from `org.mozilla.firefox` to avoid Flathub clash), rolling aarch64 sha256, BaseApp required pre-install, `.appdata.xml` skips CI validation |
 | thunderbird-nightly | `flatpaks/thunderbird-nightly/GOTCHAS.md` | x86_64 only (no aarch64), comm-central icon pinning — verify each size sha256 independently (swap of 32/64 was a bug), `--persist=.thunderbird-nightly` profile isolation, no BaseApp pre-install needed, extension stubs created in build-commands (not cleanup-commands) |
@@ -40,6 +41,17 @@ Real flatpak-tracker runtime-update issue bodies use:
 2. Strip surrounding backticks from `Package:` and runtime field values before processing
 
 Applies to: `scripts/sync-runtime-issues.py` and any task spec describing issue body format.
+
+### io.github.DenysMb.Kontainer
+
+- `appstream-external-screenshot-url` + `appstream-screenshots-not-mirrored-in-ostree`:
+  Upstream appstream metadata contains screenshots hosted at external URLs (not mirrored
+  to `https://dl.flathub.org/media`). This is a permanent exception — the app is not on
+  Flathub so screenshot mirroring never happens. Both exceptions declared in
+  `flatpaks/io.github.DenysMb.Kontainer/exceptions.json`.
+  - `appstream-external-screenshot-url` fires at the `builddir` lint stage
+  - `appstream-screenshots-not-mirrored-in-ostree` fires at the `repo` lint stage
+  Both must be present; omitting either causes the x86_64 build to fail.
 
 ## gnome-49 container: dbus setup required for e2e-install
 
@@ -93,7 +105,7 @@ x-skip-launch-check: true
 
 Applies to: **goose**, **lmstudio** (any Electron GUI app).
 
-
+## bundle-repack apps: no metainfo injection
 
 The `release.yaml` pipeline downloads a pre-built upstream `.flatpak` and repackages it as
 OCI. There is no mechanism to inject source-side files (e.g. metainfo XML) into the bundle.


### PR DESCRIPTION
## Summary

- Bumps `runtime-version` from `6.9` to `6.10` (KDE Platform)
- Sets `x-version: '1.4.1'` (was empty)
- Adds `appstream-external-screenshot-url` exception (builddir lint stage)
- Adds `appstream-screenshots-not-mirrored-in-ostree` exception (repo lint stage)
- Documents Kontainer quirks in `skills/app-gotchas.md`; restores missing `## bundle-repack apps` section header

Both screenshot exceptions are permanent: the app is not on Flathub so screenshots are never mirrored to `dl.flathub.org/media`. The two exceptions fire at different lint stages — omitting either one causes the x86_64 build to fail.

Supersedes #13 and #14 (both had incomplete fixes — #13 missing the exceptions, #14 missing the runtime bump and the repo-stage exception).

Closes #9
Closes #10