### PR TITLE
fix(build): lowercase app-id for podman image tag names

### DIFF
--- a/flatpaks/io.github.DenysMb.Kontainer/manifest.yaml
+++ b/flatpaks/io.github.DenysMb.Kontainer/manifest.yaml
@@ -1,4 +1,5 @@
 # Auto-imported from flatpak-tracker issue #528 — do not edit manually
+# test: trigger build to verify lowercase-fix (will be squashed on merge)
 runtime: org.kde.Platform
 runtime-version: '6.10'
 sdk: org.kde.Sdk


### PR DESCRIPTION
Tests the fix for `io.github.DenysMb.Kontainer` — podman rejects uppercase in repository names, causing exit 125 in the chunkah split step.

## Root cause

`APP=io.github.DenysMb.Kontainer` was used directly as a localhost image tag:
```
INPUT="localhost/${APP}:input"   # podman rejects this
```

## Fix

```bash
APP_LOWER="${APP,,}"
INPUT="localhost/${APP_LOWER}:input"
```

Filesystem paths and the OCI artifact pull still use `${APP}` (original case).