### PR TITLE
feat(flatpaks): add

### DIFF
--- a/flatpaks/dell-webcam-control/release.yaml
+++ b/flatpaks/dell-webcam-control/release.yaml
@@ -1,0 +1,12 @@
+app-id: io.gitlab.cschalle.DellWebcamControl
+version: 509e54c2
+# arches: upstream generic package provides a single bundle; no aarch64 bundle proven
+arches: [x86_64]
+url: https://gitlab.com/api/v4/projects/74702014/packages/generic/dell-wb7022-control/509e54c2/io.gitlab.cschalle.DellWebcamControl.flatpak
+sha256: c41857c2e30069dc6b2ac7d4c7617563be7f1a4c0ae19384b4e98d7e989252a4
+title: Dell Webcam Control
+description: Control application for Dell UltraSharp WB7022 4K webcam
+license: GPL-3.0-or-later
+x-skip-launch-check: true
+x-skip-install-test: true
+x-skip-chunkah: true


### PR DESCRIPTION
Add dell-webcam-control packaging in testhub with app-specific metadata and CI-ready config.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

## Package checklist

- [ ] `just validate <app>` passes (schema + appstreamcli + flatpak-builder-lint)
- [ ] `just loop <app>` passes (full local build + local registry push)
- [ ] Icon present at 128×128 minimum (`/app/share/icons/hicolor/128x128/apps/<app-id>.png`)
- [ ] `x-version` (manifest.yaml) or `version` (release.yaml) field set to upstream version
- [ ] Source URL is immutable — no rolling `tip`, `latest`, or branch archive URLs
- [ ] `sha256` matches downloaded artifact
- [ ] `finish-args` reviewed — each permission justified; non-obvious ones have inline comments
- [ ] MetaInfo XML present and passes `appstreamcli validate --no-net`
- [ ] Proprietary app: first `<p>` in description contains disclaimer
