### PR TITLE
feat(flatpaks): add

### DIFF
--- a/flatpaks/elgato-light/elgato-light-device-scanner.sh
+++ b/flatpaks/elgato-light/elgato-light-device-scanner.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="/app/share/elgato-light"
+export GSETTINGS_SCHEMA_DIR="/app/share/glib-2.0/schemas"
+
+# Helper command for standalone device scanner UI.
+exec gjs -m "${APP_DIR}/device-scanner.js" "$@"

--- a/flatpaks/elgato-light/elgato-light-preferences.sh
+++ b/flatpaks/elgato-light/elgato-light-preferences.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="/app/share/elgato-light"
+export GSETTINGS_SCHEMA_DIR="/app/share/glib-2.0/schemas"
+
+# Standalone app scope only. GNOME Shell extension runtime remains host-side.
+exec gjs -m "${APP_DIR}/preferences-app.js" "$@"

--- a/flatpaks/elgato-light/exceptions.json
+++ b/flatpaks/elgato-light/exceptions.json
@@ -1,0 +1,12 @@
+{
+    "org.linuxrising.ElgatoLight": [
+        "appid-filename-mismatch",
+        "appstream-no-flathub-manifest-key",
+        "metainfo-missing-screenshots",
+        "appstream-missing-screenshots",
+        "appstream-screenshots-not-mirrored-in-ostree",
+        "finish-args-dconf-talk-name",
+        "finish-args-unnecessary-xdg-config-dconf-rw-access",
+        "finish-args-direct-dconf-path"
+    ]
+}

--- a/flatpaks/elgato-light/manifest.yaml
+++ b/flatpaks/elgato-light/manifest.yaml
@@ -1,0 +1,48 @@
+# Chosen standalone Flatpak app-id for the GJS preferences/scanner package.
+app-id: org.linuxrising.ElgatoLight
+runtime: org.gnome.Platform
+runtime-version: "49"
+sdk: org.gnome.Sdk
+default-branch: stable
+x-version: "1.0.0"
+x-skip-launch-check: true  # GUI app: requires Wayland/X11 display; exits 1 in headless CI
+x-skip-install-test: true  # Build 1 bootstrap: not yet in testhub index; remove after first successful CI push
+x-skip-chunkah: true
+command: elgato-light-preferences
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --system-talk-name=org.freedesktop.Avahi
+  - --talk-name=ca.desrt.dconf
+  - --filesystem=xdg-run/dconf
+  - --filesystem=xdg-config/dconf
+
+modules:
+  - name: elgato-light
+    buildsystem: simple
+    build-commands:
+      - install -d /app/share/elgato-light
+      - cp -r . /app/share/elgato-light
+      - install -Dm755 elgato-light-preferences.sh /app/bin/elgato-light-preferences
+      - install -Dm755 elgato-light-device-scanner.sh /app/bin/elgato-light-device-scanner
+      - install -Dm644 org.linuxrising.ElgatoLight.desktop /app/share/applications/org.linuxrising.ElgatoLight.desktop
+      - install -Dm644 org.linuxrising.ElgatoLight.metainfo.xml /app/share/metainfo/org.linuxrising.ElgatoLight.metainfo.xml
+      - install -Dm644 org.linuxrising.ElgatoLight.svg /app/share/icons/hicolor/scalable/apps/org.linuxrising.ElgatoLight.svg
+      - install -Dm644 schemas/org.gnome.shell.extensions.elgato-light-control.gschema.xml /app/share/glib-2.0/schemas/org.gnome.shell.extensions.elgato-light-control.gschema.xml
+      - glib-compile-schemas /app/share/glib-2.0/schemas
+    sources:
+      - type: archive
+        url: https://gitlab.com/cschalle/gnome-shell-elgato-light-controller/-/archive/0f04e199c6b39f035dac9ee4e63c749bab4290be/gnome-shell-elgato-light-controller-0f04e199c6b39f035dac9ee4e63c749bab4290be.tar.gz
+        sha256: 2f96e11ab40f0006d2ee29b20e0cdaae36971ec9b047e62b2a14d7afb2284b1b
+      - type: file
+        path: elgato-light-preferences.sh
+      - type: file
+        path: elgato-light-device-scanner.sh
+      - type: file
+        path: org.linuxrising.ElgatoLight.desktop
+      - type: file
+        path: org.linuxrising.ElgatoLight.metainfo.xml
+      - type: file
+        path: org.linuxrising.ElgatoLight.svg

--- a/flatpaks/elgato-light/org.linuxrising.ElgatoLight.desktop
+++ b/flatpaks/elgato-light/org.linuxrising.ElgatoLight.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Elgato Light Preferences
+Comment=Manage Elgato light devices on your local network
+Exec=elgato-light-preferences
+Icon=org.linuxrising.ElgatoLight
+Terminal=false
+Categories=Settings;Utility;
+Keywords=elgato;light;lighting;device;
+StartupNotify=true

--- a/flatpaks/elgato-light/org.linuxrising.ElgatoLight.metainfo.xml
+++ b/flatpaks/elgato-light/org.linuxrising.ElgatoLight.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.linuxrising.ElgatoLight</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+  <name>Elgato Light Preferences</name>
+  <summary>Manage Elgato light devices discovered on the local network</summary>
+  <description>
+    <p>
+      Elgato Light Preferences is a standalone GTK/libadwaita application for
+      discovering and configuring Elgato light devices.
+    </p>
+    <p>
+      It includes a preferences interface and a device-scanner helper command
+      intended for local-network setup and control workflows.
+    </p>
+    <p>
+      Scope note: this Flatpak ships standalone app tooling only. The GNOME
+      Shell extension runtime remains host-side and is out of Flatpak scope.
+    </p>
+  </description>
+  <url type="homepage">https://gitlab.com/cschalle/gnome-shell-elgato-light-controller</url>
+  <developer id="org.linuxrising">
+    <name>linuxrising.org contributors</name>
+  </developer>
+  <launchable type="desktop-id">org.linuxrising.ElgatoLight.desktop</launchable>
+  <categories>
+    <category>Settings</category>
+    <category>Utility</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="1.0.0" date="2026-03-23"/>
+  </releases>
+</component>

--- a/flatpaks/elgato-light/org.linuxrising.ElgatoLight.svg
+++ b/flatpaks/elgato-light/org.linuxrising.ElgatoLight.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512"><rect width="512" height="512" rx="96" fill="#0b5cad"/><circle cx="256" cy="256" r="128" fill="#ffffff"/><circle cx="256" cy="256" r="72" fill="#0b5cad"/></svg>


### PR DESCRIPTION
Add elgato-light packaging in testhub with app-specific metadata and CI-ready config.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

## Package checklist

- [ ] `just validate <app>` passes (schema + appstreamcli + flatpak-builder-lint)
- [ ] `just loop <app>` passes (full local build + local registry push)
- [ ] Icon present at 128×128 minimum (`/app/share/icons/hicolor/128x128/apps/<app-id>.png`)
- [ ] `x-version` (manifest.yaml) or `version` (release.yaml) field set to upstream version
- [ ] Source URL is immutable — no rolling `tip`, `latest`, or branch archive URLs
- [ ] `sha256` matches downloaded artifact
- [ ] `finish-args` reviewed — each permission justified; non-obvious ones have inline comments
- [ ] MetaInfo XML present and passes `appstreamcli validate --no-net`
- [ ] Proprietary app: first `<p>` in description contains disclaimer
