### PR TITLE
feat(flatpaks): add

### DIFF
--- a/flatpaks/redhat-planet/release.yaml
+++ b/flatpaks/redhat-planet/release.yaml
@@ -1,0 +1,10 @@
+app-id: com.redhat.RedHatPlanet
+version: 96a56f22
+arches: [x86_64]
+url: https://gitlab.com/api/v4/projects/74314426/packages/generic/redhatplanet/96a56f22/com.redhat.RedHatPlanet.flatpak
+sha256: e7ab6978b95fadbbc4e36058e8519e7ffc60455bd877ce81e5f98c0c13129985
+title: Red Hat Planet
+description: Interactive 3D globe showing Red Hat offices with live news feed
+license: BSD-3-Clause
+x-skip-launch-check: true
+x-skip-install-test: true


### PR DESCRIPTION
Add redhat-planet packaging in testhub with app-specific metadata and CI-ready config.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

## Package checklist

- [ ] `just validate <app>` passes (schema + appstreamcli + flatpak-builder-lint)
- [ ] `just loop <app>` passes (full local build + local registry push)
- [ ] Icon present at 128×128 minimum (`/app/share/icons/hicolor/128x128/apps/<app-id>.png`)
- [ ] `x-version` (manifest.yaml) or `version` (release.yaml) field set to upstream version
- [ ] Source URL is immutable — no rolling `tip`, `latest`, or branch archive URLs
- [ ] `sha256` matches downloaded artifact
- [ ] `finish-args` reviewed — each permission justified; non-obvious ones have inline comments
- [ ] MetaInfo XML present and passes `appstreamcli validate --no-net`
- [ ] Proprietary app: first `<p>` in description contains disclaimer
