### PR TITLE
feat(flatpaks): add

### DIFF
--- a/flatpaks/xmms-resuscitated/release.yaml
+++ b/flatpaks/xmms-resuscitated/release.yaml
@@ -1,0 +1,14 @@
+app-id: org.xmms.Resuscitated
+version: build-13
+# Strategy (#22): release.yaml single-arch x86_64 using current GitLab CI artifact.
+# Volatility note: job-artifact URLs may expire or disappear; this pin is deterministic now
+# (exact URL + sha256) but may require periodic refresh when upstream prunes artifacts.
+arches: [x86_64]
+url: https://gitlab.com/cschalle/xmms-resuscitated/-/jobs/artifacts/build-13/raw/xmms-resuscitated-x86_64.flatpak?job=flatpak-x86_64
+sha256: c95698250179d57caf0c0f9bf560aceb618385ce6f2c636b90e6bf7f3af98bc2
+title: XMMS Resuscitated
+description: XMMS Resuscitated media player - Flatpak repack
+license: GPL-2.0-or-later
+x-skip-launch-check: true
+x-skip-install-test: true
+x-skip-chunkah: true


### PR DESCRIPTION
Add xmms-resuscitated packaging in testhub with app-specific metadata and CI-ready config.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

## Package checklist

- [ ] `just validate <app>` passes (schema + appstreamcli + flatpak-builder-lint)
- [ ] `just loop <app>` passes (full local build + local registry push)
- [ ] Icon present at 128×128 minimum (`/app/share/icons/hicolor/128x128/apps/<app-id>.png`)
- [ ] `x-version` (manifest.yaml) or `version` (release.yaml) field set to upstream version
- [ ] Source URL is immutable — no rolling `tip`, `latest`, or branch archive URLs
- [ ] `sha256` matches downloaded artifact
- [ ] `finish-args` reviewed — each permission justified; non-obvious ones have inline comments
- [ ] MetaInfo XML present and passes `appstreamcli validate --no-net`
- [ ] Proprietary app: first `<p>` in description contains disclaimer
