### PR TITLE
feat(elgato-light): promote to testhub index

### DIFF
--- a/flatpaks/elgato-light/manifest.yaml
+++ b/flatpaks/elgato-light/manifest.yaml
@@ -6,7 +6,6 @@ sdk: org.gnome.Sdk
 default-branch: stable
 x-version: "1.0.0"
 x-skip-launch-check: true  # GUI app: requires Wayland/X11 display; exits 1 in headless CI
-x-skip-install-test: true  # Build 1 bootstrap: not yet in testhub index; remove after first successful CI push
 x-skip-chunkah: true
 command: elgato-light-preferences
 finish-args:


### PR DESCRIPTION
Removes `x-skip-install-test: true` bootstrap flag. The `exceptions.json` is complete and there are no known build blockers. First CI push will install-test the app and add it to the testhub Flatpak remote.