### PR TITLE
feat(wmdock): promote to testhub index

### DIFF
--- a/flatpaks/wmdock/manifest.yaml
+++ b/flatpaks/wmdock/manifest.yaml
@@ -5,7 +5,6 @@ sdk: org.gnome.Sdk
 default-branch: stable
 x-version: "0.1.15"
 x-skip-launch-check: true  # GUI app: requires Wayland/X11 display; exits 1 in headless CI
-x-skip-install-test: true  # Build 1 bootstrap: not yet in testhub index; remove after first successful CI push
 x-skip-chunkah: true
 command: wmakerdock-config
 finish-args:


### PR DESCRIPTION
Removes `x-skip-install-test: true` bootstrap flag. The `exceptions.json` is complete and there are no known build blockers. First CI push will install-test the app and add it to the testhub Flatpak remote.