### PR TITLE
feat(Kontainer): promote to testhub index

### DIFF
--- a/flatpaks/io.github.DenysMb.Kontainer/manifest.yaml
+++ b/flatpaks/io.github.DenysMb.Kontainer/manifest.yaml
@@ -28,5 +28,4 @@ default-branch: stable
 x-arches:
 - x86_64
 x-skip-chunkah: true
-x-skip-install-test: true
 x-skip-launch-check: true


### PR DESCRIPTION
Removes `x-skip-install-test: true` bootstrap flag. The `exceptions.json` is complete and there are no known build blockers. First CI push will install-test the app and add it to the testhub Flatpak remote.