### PR TITLE
feat(Tuner): promote to testhub index

### DIFF
--- a/flatpaks/org.altlinux.Tuner/manifest.yaml
+++ b/flatpaks/org.altlinux.Tuner/manifest.yaml
@@ -98,6 +98,5 @@ modules:
 x-version: '0.5.0'
 x-skip-launch-check: true
 x-skip-chunkah: true
-x-skip-install-test: true
 x-arches:
 - x86_64


### PR DESCRIPTION
Removes `x-skip-install-test: true` bootstrap flag. The manifest already has `runtime-version: 49` and libpeas is built with `-Dgjs=false` (mozjs-128 not available in gnome-49), resolving the blocker tracked in issue 45. Only x86_64 is enabled via `x-arches`.