### PR TITLE
fix(goose): update to v1.29.1, fix repo URL (block→aaif-goose)

### DIFF
--- a/flatpaks/goose/release.yaml
+++ b/flatpaks/goose/release.yaml
@@ -1,9 +1,9 @@
 app-id: io.github.block.Goose
-version: v1.29.0
+version: v1.29.1
 # arches: upstream only ships x86_64 .flatpak; no aarch64 bundle available
 arches: [x86_64]
-url: https://github.com/block/goose/releases/download/v1.29.0/io.github.block.Goose_stable_x86_64.flatpak
-sha256: 76500086b7c48f505de4c406e0c85f9d89ae68c3f4dde3e0790d278ce488dec8
+url: https://github.com/aaif-goose/goose/releases/download/v1.29.1/io.github.block.Goose_stable_x86_64.flatpak
+sha256: cf815dc23fe287bf9eeccc31e1affdf2c701d00215d491ba8b5334edb4981d96
 title: Goose
 description: Goose AI agent - Flatpak repack
 license: Apache-2.0


### PR DESCRIPTION
The `block/goose` GitHub org was renamed to `aaif-goose`. The old URL still redirects (301) but should be updated to the canonical location. Also bumps version from v1.29.0 to v1.29.1 (latest release).