### PR TITLE
fix(saturn): remove dead pcostanza/closer-mop git ref

### DIFF
--- a/flatpaks/saturn/manifest.yaml
+++ b/flatpaks/saturn/manifest.yaml
@@ -55,10 +55,11 @@ modules:
         url: https://github.com/sharplispers/split-sequence.git
         commit: 89a10b4d697f03eb32ade3c373c4fd69800a841a
         dest: split-sequence
-      - type: git
-        url: https://github.com/pcostanza/closer-mop.git
-        commit: c6b1f2db0d77aea961e871f268b6fdcdc90c7510
+      - type: archive
+        url: https://beta.quicklisp.org/archive/closer-mop/2026-01-01/closer-mop-20260101-git.tgz
+        sha256: bea987c69b906d9a94b5e19e6d3f1665a1646d511f080076637195ed4bc7089f
         dest: closer-mop
+        strip-components: 1
       - type: git
         url: https://github.com/trivial-garbage/trivial-garbage.git
         commit: 3474f6414b73d4e3aa2d5c53080f4247a34f6380


### PR DESCRIPTION
Replace the dead https://github.com/pcostanza/closer-mop.git source (returns 404, causing Renovate git ls-remote to fail for the entire org) with a stable archive from the Quicklisp distribution: https://beta.quicklisp.org/archive/closer-mop/2026-01-01/closer-mop-20260101-git.tgz

Using an archive source eliminates the git ls-remote call that Renovate was making against the defunct upstream repo.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

## Package checklist

- [ ] `just validate <app>` passes (schema + appstreamcli + flatpak-builder-lint)
- [ ] `just loop <app>` passes (full local build + local registry push)
- [ ] Icon present at 128×128 minimum (`/app/share/icons/hicolor/128x128/apps/<app-id>.png`)
- [ ] `x-version` (manifest.yaml) or `version` (release.yaml) field set to upstream version
- [ ] Source URL is immutable — no rolling `tip`, `latest`, or branch archive URLs
- [ ] `sha256` matches downloaded artifact
- [ ] `finish-args` reviewed — each permission justified; non-obvious ones have inline comments
- [ ] MetaInfo XML present and passes `appstreamcli validate --no-net`
- [ ] Proprietary app: first `<p>` in description contains disclaimer
